### PR TITLE
增加 Python 和 Java 服务间相互链路传递的示例

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -10,3 +10,4 @@
 - [Opentelemetry Collector集成指南:Collector部署和采样示例](https://github.com/laziobird/otel-collector-java)
 - [.Net指南:Opentelemetry+Jaeger](https://github.com/iioter/ExploringIoTDistributedTracingNet6)
 - [Go指南:Opentelemetry+Jaeger+Grafana](https://github.com/cloudwego/kitex-examples/tree/main/opentelemetry)
+- [Python 到 Java 相互间 Context Propagation 的示例](https://github.com/LronDC/ContextPropagationBetweenPythonAndJava/)


### PR DESCRIPTION
1. 增加了 Python 和 Java 服务间相互链路传递的示例到入手指南中。